### PR TITLE
Added audio + seeking support to the container experiment.

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -27,6 +27,7 @@
 
 #if PLATFORM(COCOA) && ENABLE(WEBM_EXPERIMENT)
 
+#include "AudioTrackPrivateWebM.h"
 #include "HTTPHeaderNames.h"
 #include "MediaPlayerPrivate.h"
 #include "NotImplemented.h"
@@ -34,20 +35,25 @@
 #include "PlatformMediaResourceLoader.h"
 #include "SampleBufferDisplayLayer.h"
 #include "SampleMap.h"
+#include "TextTrackRepresentation.h"
 #include "VideoFrame.h"
 #include "VideoLayerManagerObjC.h"
-#include <wtf/WeakPtr.h>
+#include "VideoTrackPrivateWebM.h"
+#include <wtf/HashMap.h>
 #include <wtf/LoggerHelper.h>
+#include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 
+OBJC_CLASS AVSampleBufferAudioRenderer;
 OBJC_CLASS AVSampleBufferDisplayLayer;
 
 namespace WebCore {
 
 class WebMResourceClient;
-class WebMVideoData;
 
 class MediaPlayerPrivateWebM
-    : public MediaPlayerPrivateInterface
+    : public CanMakeWeakPtr<MediaPlayerPrivateWebM>
+    , public MediaPlayerPrivateInterface
     , private LoggerHelper
 {
     WTF_MAKE_FAST_ALLOCATED;
@@ -57,6 +63,10 @@ public:
     
     static void registerMediaEngine(MediaEngineRegistrar);
     
+    void dataReceived(const SharedBuffer&);
+    void loadFinished(const FragmentedSharedBuffer&);
+    
+private:
     void load(const String&) final;
     
 #if ENABLE(MEDIA_SOURCE)
@@ -70,6 +80,9 @@ public:
     
     PlatformLayer* platformLayer() const final;
     
+    bool supportsPictureInPicture() const override { return true; }
+    bool supportsFullscreen() const final { return true; }
+    
     void play() final;
     void pause() final;
     
@@ -82,14 +95,27 @@ public:
     
     MediaTime currentMediaTime() const final;
     MediaTime durationMediaTime() const final { return m_duration; };
+    MediaTime startTime() const final { return MediaTime::zeroTime(); };
+    MediaTime initialTime() const final { return MediaTime::zeroTime(); };
     
+    void seek(const MediaTime&) final;
     bool seeking() const final { return m_seeking; };
     
+    void setRateDouble(double) final;
+    double rate() const final { return m_rate; }
+    double effectiveRate() const final;
+    
     bool paused() const final { return m_paused; };
+    
+    void setVolume(float) final;
+    void setMuted(bool) final;
     
     MediaPlayer::NetworkState networkState() const final { return m_networkState; };
     MediaPlayer::ReadyState readyState() const final { return m_readyState; };
     
+    std::unique_ptr<PlatformTimeRanges> seekable() const final;
+    MediaTime maxMediaTimeSeekable() const final { return durationMediaTime(); }
+    MediaTime minMediaTimeSeekable() const final { return startTime(); }
     std::unique_ptr<PlatformTimeRanges> buffered() const final;
     
     bool didLoadingProgress() const final;
@@ -102,36 +128,56 @@ public:
     void setHasAudio(bool);
     void setHasVideo(bool);
     void setDuration(const MediaTime&);
+    void setDuration(MediaTime&&);
     void setNetworkState(MediaPlayer::NetworkState);
     void setReadyState(MediaPlayer::ReadyState);
     void characteristicsChanged();
     
     bool supportsAcceleratedRendering() const final { return true; };
     
-    void dataReceived(const SharedBuffer&);
-    void loadFinished(const FragmentedSharedBuffer&);
+    RetainPtr<PlatformLayer> createVideoFullscreenLayer() final;
+    void setVideoFullscreenLayer(PlatformLayer*, Function<void()>&& completionHandler) final;
+    void setVideoFullscreenFrame(FloatRect) final;
     
-    std::unique_ptr<WebMVideoData> demuxWebMData(SharedBuffer&);
+    bool requiresTextTrackRepresentation() const final;
+    void setTextTrackRepresentation(TextTrackRepresentation*) final;
+    void syncTextTrackBounds() final;
+    
+    void enqueueSamples();
+    void enqueueSamplesForTime(const MediaTime&);
+    
+    void demuxWebMData(SharedBuffer&);
     
     void ensureLayer();
-    void layersAreInitialized(IntSize, bool);
+    void ensureAudioRenderer();
+    
+    void destroyLayer();
+    void destroyAudioRenderer();
+    void clearTracks();
     
     const Logger& logger() const final { return m_logger.get(); }
-    const char* logClassName() const override { return "MediaPlayerPrivateWebM"; }
+    const char* logClassName() const final { return "MediaPlayerPrivateWebM"; }
     const void* logIdentifier() const final { return reinterpret_cast<const void*>(m_logIdentifier); }
     WTFLogChannel& logChannel() const final;
     
-private:
     friend class MediaPlayerFactoryWebM;
+    static bool isAvailable();
     static void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>&);
     static MediaPlayer::SupportsType supportsType(const MediaEngineSupportParameters&);
     
     MediaPlayer* m_player;
     RetainPtr<AVSampleBufferRenderSynchronizer> m_synchronizer;
+    RetainPtr<id> m_durationObserver;
     WeakPtr<WebMResourceClient> m_resourceClient;
     
-    std::unique_ptr<WebMVideoData> m_webmData;
+    Vector<RefPtr<VideoTrackPrivateWebM>> m_videoTracks;
+    Vector<RefPtr<AudioTrackPrivateWebM>> m_audioTracks;
+    
     RetainPtr<AVSampleBufferDisplayLayer> m_displayLayer;
+    RetainPtr<AVSampleBufferAudioRenderer> m_audioRenderer;
+    
+    SampleMap m_videoSamples;
+    SampleMap m_audioSamples;
     
     MediaPlayer::NetworkState m_networkState;
     MediaPlayer::ReadyState m_readyState;
@@ -145,6 +191,7 @@ private:
     bool m_hasVideo;
     MediaTime m_currentTime;
     MediaTime m_duration;
+    double m_rate;
     bool m_seeking;
     bool m_paused;
     bool m_visible;

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -106,17 +106,6 @@ void WebMResourceClient::loadFinished(PlatformMediaResource&, const NetworkLoadM
     m_parent.loadFinished(*m_buffer.get());
 }
 
-class WebMVideoData {
-    WTF_MAKE_FAST_ALLOCATED;
-public:
-    Ref<SharedBuffer> m_buffer;
-#if ENABLE(MEDIA_SOURCE)
-    Ref<VideoTrackPrivateWebM> m_track;
-#endif
-    MediaTime m_duration;
-    SampleMap m_samples;
-};
-
 MediaPlayerPrivateWebM::MediaPlayerPrivateWebM(MediaPlayer* player)
     : m_player(player)
     , m_synchronizer(adoptNS([PAL::allocAVSampleBufferRenderSynchronizerInstance() init]))
@@ -130,6 +119,7 @@ MediaPlayerPrivateWebM::MediaPlayerPrivateWebM(MediaPlayer* player)
     , m_hasVideo(false)
     , m_currentTime(MediaTime::zeroTime())
     , m_duration(MediaTime::zeroTime())
+    , m_rate(1)
     , m_seeking(false)
     , m_paused(false)
     , m_visible(false)
@@ -140,31 +130,39 @@ MediaPlayerPrivateWebM::MediaPlayerPrivateWebM(MediaPlayer* player)
 MediaPlayerPrivateWebM::~MediaPlayerPrivateWebM()
 {
     INFO_LOG(LOGIDENTIFIER);
+    
+    if (m_durationObserver)
+        [m_synchronizer removeTimeObserver:m_durationObserver.get()];
+    
+    destroyLayer();
+    destroyAudioRenderer();
+}
+
+void MediaPlayerPrivateWebM::dataReceived(const SharedBuffer&)
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
+}
+
+void MediaPlayerPrivateWebM::loadFinished(const FragmentedSharedBuffer& fragmentedBuffer)
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
+    
+    auto buffer = fragmentedBuffer.makeContiguous();
+    demuxWebMData(buffer);
+    
+    ensureLayer();
+    ensureAudioRenderer();
+    enqueueSamples();
+    
+    setReadyState(MediaPlayer::ReadyState::HaveEnoughData);
+    setNetworkState(MediaPlayer::NetworkState::Idle);
+    m_player->firstVideoFrameAvailable();
 }
 
 static HashSet<String, ASCIICaseInsensitiveHash>& mimeTypeCache()
 {
     static NeverDestroyed cache = HashSet<String, ASCIICaseInsensitiveHash> { "video/webm"_s };
     return cache;
-}
-
-void MediaPlayerPrivateWebM::getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types)
-{
-    types = mimeTypeCache();
-}
-
-MediaPlayer::SupportsType MediaPlayerPrivateWebM::supportsType(const MediaEngineSupportParameters& parameters)
-{
-    auto containerType = parameters.type.containerType();
-
-    if (!containerType.isEmpty() && mimeTypeCache().contains(containerType)) {
-        if (parameters.type.codecs().isEmpty())
-            return MediaPlayer::SupportsType::MayBeSupported;
-
-        return MediaPlayer::SupportsType::IsSupported;
-    }
-
-    return MediaPlayer::SupportsType::IsNotSupported;
 }
 
 void MediaPlayerPrivateWebM::load(const String& url)
@@ -233,15 +231,16 @@ PlatformLayer* MediaPlayerPrivateWebM::platformLayer() const
 void MediaPlayerPrivateWebM::play()
 {
     m_paused = false;
-    [m_synchronizer setRate:1];
-    m_player->rateChanged();
+    [m_synchronizer setRate:m_rate];
+    
+    if (currentMediaTime() >= durationMediaTime())
+        seek(MediaTime::zeroTime());
 }
 
 void MediaPlayerPrivateWebM::pause()
 {
     m_paused = true;
     [m_synchronizer setRate:0];
-    m_player->rateChanged();
 }
 
 void MediaPlayerPrivateWebM::setPageIsVisible(bool visible)
@@ -260,13 +259,31 @@ MediaTime MediaPlayerPrivateWebM::currentMediaTime() const
     MediaTime synchronizerTime = PAL::toMediaTime(PAL::CMTimebaseGetTime([m_synchronizer timebase]));
     if (synchronizerTime < MediaTime::zeroTime())
         return MediaTime::zeroTime();
+    if (synchronizerTime > durationMediaTime())
+        return durationMediaTime();
     
     return synchronizerTime;
 }
 
+void MediaPlayerPrivateWebM::seek(const MediaTime& time)
+{
+    ALWAYS_LOG(LOGIDENTIFIER, "time = ", time);
+    
+    [m_displayLayer flush];
+    [m_audioRenderer flush];
+    enqueueSamplesForTime(time);
+    [m_synchronizer setRate:effectiveRate() time:PAL::toCMTime(time)];
+    m_player->timeChanged();
+}
+
+std::unique_ptr<PlatformTimeRanges> MediaPlayerPrivateWebM::seekable() const
+{
+    return makeUnique<PlatformTimeRanges>(minMediaTimeSeekable(), maxMediaTimeSeekable());
+};
+
 std::unique_ptr<PlatformTimeRanges> MediaPlayerPrivateWebM::buffered() const
 {
-    return makeUnique<PlatformTimeRanges>();
+    return makeUnique<PlatformTimeRanges>(MediaTime::zeroTime(), durationMediaTime());
 };
 
 bool MediaPlayerPrivateWebM::didLoadingProgress() const
@@ -304,11 +321,65 @@ void MediaPlayerPrivateWebM::setHasVideo(bool hasVideo)
 
 void MediaPlayerPrivateWebM::setDuration(const MediaTime& duration)
 {
+    setDuration(MediaTime(duration));
+}
+
+void MediaPlayerPrivateWebM::setDuration(MediaTime&& duration)
+{
     if (duration == m_duration)
         return;
+    
+    if (m_durationObserver)
+        [m_synchronizer removeTimeObserver:m_durationObserver.get()];
+    
+    NSArray* times = @[[NSValue valueWithCMTime:PAL::toCMTime(duration)]];
+    
+    auto logSiteIdentifier = LOGIDENTIFIER;
+    DEBUG_LOG(logSiteIdentifier, duration);
+    UNUSED_PARAM(logSiteIdentifier);
+    
+    m_durationObserver = [m_synchronizer addBoundaryTimeObserverForTimes:times queue:dispatch_get_main_queue() usingBlock:[weakThis = WeakPtr { *this }, duration, logSiteIdentifier, this] {
+        if (!weakThis)
+            return;
 
-    m_duration = duration;
+        MediaTime now = weakThis->currentMediaTime();
+        ALWAYS_LOG(logSiteIdentifier, "boundary time observer called, now = ", now);
+
+        weakThis->pause();
+        if (now < duration) {
+            ERROR_LOG(logSiteIdentifier, "ERROR: boundary time observer called before duration");
+            [weakThis->m_synchronizer setRate:0 time:PAL::toCMTime(duration)];
+        }
+        weakThis->m_player->timeChanged();
+
+    }];
+    
+    m_duration = WTFMove(duration);
     m_player->durationChanged();
+}
+
+void MediaPlayerPrivateWebM::setRateDouble(double rate)
+{
+    if (rate == m_rate)
+        return;
+    
+    m_rate = std::max<double>(rate, 0);
+    m_player->rateChanged();
+}
+
+double MediaPlayerPrivateWebM::effectiveRate() const
+{
+    return PAL::CMTimebaseGetRate([m_synchronizer timebase]);
+}
+
+void MediaPlayerPrivateWebM::setVolume(float volume)
+{
+    [m_audioRenderer setVolume:volume];
+}
+
+void MediaPlayerPrivateWebM::setMuted(bool muted)
+{
+    [m_audioRenderer setMuted:muted];
 }
 
 void MediaPlayerPrivateWebM::setNetworkState(MediaPlayer::NetworkState state)
@@ -334,42 +405,107 @@ void MediaPlayerPrivateWebM::characteristicsChanged()
     m_player->characteristicChanged();
 }
 
-void MediaPlayerPrivateWebM::dataReceived(const SharedBuffer&)
+RetainPtr<PlatformLayer> MediaPlayerPrivateWebM::createVideoFullscreenLayer()
 {
-    ALWAYS_LOG(LOGIDENTIFIER);
+    return adoptNS([[CALayer alloc] init]);
 }
 
-void MediaPlayerPrivateWebM::loadFinished(const FragmentedSharedBuffer& fragmentedBuffer)
+void MediaPlayerPrivateWebM::setVideoFullscreenLayer(PlatformLayer *videoFullscreenLayer, WTF::Function<void()>&& completionHandler)
 {
-    ALWAYS_LOG(LOGIDENTIFIER);
+    m_videoLayerManager->setVideoFullscreenLayer(videoFullscreenLayer, WTFMove(completionHandler), nullptr);
+}
+
+void MediaPlayerPrivateWebM::setVideoFullscreenFrame(FloatRect frame)
+{
+    m_videoLayerManager->setVideoFullscreenFrame(frame);
+}
+
+bool MediaPlayerPrivateWebM::requiresTextTrackRepresentation() const
+{
+    return m_videoLayerManager->videoFullscreenLayer();
+}
     
-    auto buffer = fragmentedBuffer.makeContiguous();
-    m_webmData = demuxWebMData(buffer);
-    ensureLayer();
-    for (auto& samplePair : m_webmData->m_samples.presentationOrder()) {
-        auto sampleBuffer = samplePair.second.get()->platformSample().sample.cmSampleBuffer;
+void MediaPlayerPrivateWebM::syncTextTrackBounds()
+{
+    m_videoLayerManager->syncTextTrackBounds();
+}
+    
+void MediaPlayerPrivateWebM::setTextTrackRepresentation(TextTrackRepresentation* representation)
+{
+    auto* representationLayer = representation ? representation->platformLayer() : nil;
+    m_videoLayerManager->setTextTrackRepresentationLayer(representationLayer);
+}
+
+void MediaPlayerPrivateWebM::enqueueSamples()
+{
+    enqueueSamplesForTime(currentMediaTime());
+}
+
+void MediaPlayerPrivateWebM::enqueueSamplesForTime(const MediaTime& time)
+{
+    // Find the sample which contains the current presentation time.
+    auto currentSamplePTSIterator = m_videoSamples.presentationOrder().findSampleContainingPresentationTime(time);
+    
+    if (currentSamplePTSIterator == m_videoSamples.presentationOrder().end()) {
+        currentSamplePTSIterator = m_videoSamples.presentationOrder().findSampleStartingOnOrAfterPresentationTime(time);
+        
+        if (currentSamplePTSIterator == m_videoSamples.presentationOrder().end())
+            return;
+    }
+        
+    // Search backward for the previous sync sample.
+    DecodeOrderSampleMap::KeyType decodeKey(currentSamplePTSIterator->second->decodeTime(), currentSamplePTSIterator->second->presentationTime());
+    auto currentSampleDTSIterator = m_videoSamples.decodeOrder().findSampleWithDecodeKey(decodeKey);
+    ASSERT(currentSampleDTSIterator != m_videoSamples.decodeOrder().end());
+    
+    auto reverseCurrentSampleIter = --DecodeOrderSampleMap::reverse_iterator(currentSampleDTSIterator);
+    auto reverseLastSyncSampleIter = m_videoSamples.decodeOrder().findSyncSamplePriorToDecodeIterator(reverseCurrentSampleIter);
+    if (reverseLastSyncSampleIter == m_videoSamples.decodeOrder().rend())
+        return;
+    
+    // Enqueue non-displaying samples
+    for (auto iter = reverseLastSyncSampleIter; iter != reverseCurrentSampleIter; --iter) {
+        auto copy = iter->second->createNonDisplayingCopy();
+        auto sampleBuffer = copy.get().platformSample().sample.cmSampleBuffer;
+        [m_displayLayer enqueueSampleBuffer:sampleBuffer];
+    }
+    
+    for (auto iter = currentSampleDTSIterator; iter != m_videoSamples.decodeOrder().end(); ++iter) {
+        auto sampleBuffer = iter->second.get()->platformSample().sample.cmSampleBuffer;
+        
         CMFormatDescriptionRef formatDescription = PAL::CMSampleBufferGetFormatDescription(sampleBuffer);
+        auto mediaType = PAL::CMFormatDescriptionGetMediaType(formatDescription);
+        
+        ASSERT(mediaType == kCMMediaType_Video);
         FloatSize formatSize = FloatSize(PAL::CMVideoFormatDescriptionGetPresentationDimensions(formatDescription, true, true));
         
         if (formatSize != m_naturalSize)
             setNaturalSize(formatSize);
         
         [m_displayLayer enqueueSampleBuffer:sampleBuffer];
+        setHasVideo(true);
     }
-    setReadyState(MediaPlayer::ReadyState::HaveEnoughData);
-    setHasVideo(true);
-    setDuration(m_webmData->m_duration);
-    setNetworkState(MediaPlayer::NetworkState::Idle);
+    
+
+    for (auto& samplePair : m_audioSamples.presentationOrder()) {
+        auto sampleBuffer = samplePair.second.get()->platformSample().sample.cmSampleBuffer;
+
+        CMFormatDescriptionRef formatDescription = PAL::CMSampleBufferGetFormatDescription(sampleBuffer);
+        auto mediaType = PAL::CMFormatDescriptionGetMediaType(formatDescription);
+
+        if(mediaType == kCMMediaType_Audio) {
+            [m_audioRenderer enqueueSampleBuffer:sampleBuffer];
+            setHasAudio(true);
+        }
+    }
 }
 
-std::unique_ptr<WebMVideoData> MediaPlayerPrivateWebM::demuxWebMData(SharedBuffer& buffer)
+void MediaPlayerPrivateWebM::demuxWebMData(SharedBuffer& buffer)
 {
     auto parser = adoptRef(new SourceBufferParserWebM());
     bool error = false;
     std::optional<uint64_t> videoTrackId;
-    MediaTime duration;
-    RefPtr<VideoTrackPrivateWebM> track;
-    SampleMap samples;
+    std::optional<uint64_t> audioTrackId;
     
     parser->setDidEncounterErrorDuringParsingCallback([&](uint64_t) {
         error = true;
@@ -377,26 +513,33 @@ std::unique_ptr<WebMVideoData> MediaPlayerPrivateWebM::demuxWebMData(SharedBuffe
     parser->setDidParseInitializationDataCallback([&](SourceBufferParserWebM::InitializationSegment&& init) {
         for (auto& videoTrack : init.videoTracks) {
             if (videoTrack.track && videoTrack.track->trackUID()) {
-                duration = init.duration;
                 videoTrackId = videoTrack.track->trackUID();
-                track = static_pointer_cast<VideoTrackPrivateWebM>(videoTrack.track);
-                return;
+                auto track = static_pointer_cast<VideoTrackPrivateWebM>(videoTrack.track);
+                m_videoTracks.append(track);
             }
         }
+        
+        for (auto& audioTrack : init.audioTracks) {
+            if (audioTrack.track && audioTrack.track->trackUID()) {
+                audioTrackId = audioTrack.track->trackUID();
+                auto track = static_pointer_cast<AudioTrackPrivateWebM>(audioTrack.track);
+                m_audioTracks.append(track);
+            }
+        }
+        
+        setDuration(WTFMove(init.duration));
     });
     parser->setDidProvideMediaDataCallback([&](Ref<MediaSampleAVFObjC>&& sample, uint64_t trackID, const String&) {
-        if (!videoTrackId || trackID != *videoTrackId)
-            return;
-        samples.addSample(WTFMove(sample));
+        if (videoTrackId && trackID == *videoTrackId)
+            m_videoSamples.addSample(WTFMove(sample));
+        else if (audioTrackId && trackID == *audioTrackId)
+            m_audioSamples.addSample(WTFMove(sample));
     });
     parser->setCallOnClientThreadCallback([](auto&& function) {
         function();
     });
     SourceBufferParser::Segment segment(Ref { buffer });
     parser->appendData(WTFMove(segment));
-    if (!track)
-        return nullptr;
-    return makeUnique<WebMVideoData>(WebMVideoData { buffer, track.releaseNonNull(), WTFMove(duration), WTFMove(samples) });
 }
 
 void MediaPlayerPrivateWebM::ensureLayer()
@@ -406,7 +549,7 @@ void MediaPlayerPrivateWebM::ensureLayer()
     
     m_displayLayer = adoptNS([PAL::allocAVSampleBufferDisplayLayerInstance() init]);
 #ifndef NDEBUG
-    [m_displayLayer setName:@"MediaPlayerPrivateMediaSource AVSampleBufferDisplayLayer"];
+    [m_displayLayer setName:@"MediaPlayerPrivateWebM AVSampleBufferDisplayLayer"];
 #endif
     
     ERROR_LOG_IF(!m_displayLayer, LOGIDENTIFIER, "Creating the AVSampleBufferDisplayLayer failed.");
@@ -425,6 +568,86 @@ void MediaPlayerPrivateWebM::ensureLayer()
     
     m_videoLayerManager->setVideoLayer(m_displayLayer.get(), snappedIntRect(m_player->playerContentBoxRect()).size());
     m_player->renderingModeChanged();
+}
+
+void MediaPlayerPrivateWebM::ensureAudioRenderer()
+{
+    if (m_audioRenderer)
+        return;
+    
+    m_audioRenderer = adoptNS([PAL::allocAVSampleBufferAudioRendererInstance() init]);
+
+    if (!m_audioRenderer) {
+        ERROR_LOG(LOGIDENTIFIER, "-[AVSampleBufferAudioRenderer init] returned nil! bailing!");
+        ASSERT_NOT_REACHED();
+        
+        setNetworkState(MediaPlayer::NetworkState::DecodeError);
+        return;
+    }
+    
+    [m_audioRenderer setMuted:m_player->muted()];
+    [m_audioRenderer setVolume:m_player->volume()];
+    [m_audioRenderer setAudioTimePitchAlgorithm:(m_player->preservesPitch() ? AVAudioTimePitchAlgorithmSpectral : AVAudioTimePitchAlgorithmVarispeed)];
+    
+#if HAVE(AUDIO_OUTPUT_DEVICE_UNIQUE_ID)
+    auto deviceId = m_player->audioOutputDeviceIdOverride();
+    if (!deviceId.isNull() && m_audioRenderer) {
+        if (deviceId.isEmpty())
+            m_audioRenderer.get().audioOutputDeviceUniqueID = nil;
+        else
+            m_audioRenderer.get().audioOutputDeviceUniqueID = deviceId;
+    }
+#endif
+    
+    @try {
+        [m_synchronizer addRenderer:m_audioRenderer.get()];
+    } @catch(NSException *exception) {
+        ERROR_LOG(LOGIDENTIFIER, "-[AVSampleBufferRenderSynchronizer addRenderer:] threw an exception: ", [[exception name] UTF8String], ", reason : ", [[exception reason] UTF8String]);
+        ASSERT_NOT_REACHED();
+
+        setNetworkState(MediaPlayer::NetworkState::DecodeError);
+        return;
+    }
+    
+    characteristicsChanged();
+}
+
+void MediaPlayerPrivateWebM::destroyLayer()
+{
+    if (!m_displayLayer)
+        return;
+    
+    CMTime currentTime = PAL::CMTimebaseGetTime([m_synchronizer timebase]);
+    [m_synchronizer removeRenderer:m_displayLayer.get() atTime:currentTime withCompletionHandler:^(BOOL){
+        // No-op.
+    }];
+    
+    m_videoLayerManager->didDestroyVideoLayer();
+    [m_displayLayer flush];
+    [m_displayLayer stopRequestingMediaData];
+    m_displayLayer = nullptr;
+    m_player->renderingModeChanged();
+}
+
+void MediaPlayerPrivateWebM::destroyAudioRenderer()
+{
+    if (!m_audioRenderer)
+        return;
+    
+    [m_audioRenderer flush];
+    [m_audioRenderer stopRequestingMediaData];
+    m_audioRenderer = nullptr;
+}
+
+void MediaPlayerPrivateWebM::clearTracks()
+{
+    for (auto& track : m_videoTracks)
+        track->setSelectedChangedCallback(nullptr);
+    m_videoTracks.clear();
+
+    for (auto& track : m_audioTracks)
+        track->setEnabledChangedCallback(nullptr);
+    m_audioTracks.clear();
 }
 
 WTFLogChannel& MediaPlayerPrivateWebM::logChannel() const
@@ -454,7 +677,38 @@ private:
 
 void MediaPlayerPrivateWebM::registerMediaEngine(MediaEngineRegistrar registrar)
 {
+    if (!isAvailable())
+        return;
+    
     registrar(makeUnique<MediaPlayerFactoryWebM>());
+}
+
+bool MediaPlayerPrivateWebM::isAvailable()
+{
+    return PAL::isAVFoundationFrameworkAvailable()
+        && PAL::isCoreMediaFrameworkAvailable()
+        && PAL::getAVSampleBufferAudioRendererClass()
+        && PAL::getAVSampleBufferRenderSynchronizerClass()
+        && class_getInstanceMethod(PAL::getAVSampleBufferAudioRendererClass(), @selector(setMuted:));
+}
+
+void MediaPlayerPrivateWebM::getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types)
+{
+    types = mimeTypeCache();
+}
+
+MediaPlayer::SupportsType MediaPlayerPrivateWebM::supportsType(const MediaEngineSupportParameters& parameters)
+{
+    auto containerType = parameters.type.containerType();
+
+    if (!containerType.isEmpty() && mimeTypeCache().contains(containerType)) {
+        if (parameters.type.codecs().isEmpty())
+            return MediaPlayer::SupportsType::MayBeSupported;
+
+        return MediaPlayer::SupportsType::IsSupported;
+    }
+
+    return MediaPlayer::SupportsType::IsNotSupported;
 }
 
 } // namespace WebCore


### PR DESCRIPTION
<pre>
Added audio + seeking support.

Patch by Youssef Soliman &lt;y_soliman@apple.com&gt; on 2022-05-27.

This change brings audio playback and seeking support to the media
player. Modifying the playback rate and fullscreen playback support has
also been added.

* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::MediaPlayerPrivateWebM):
(WebCore::MediaPlayerPrivateWebM::~MediaPlayerPrivateWebM):
(WebCore::MediaPlayerPrivateWebM::dataReceived):
(WebCore::MediaPlayerPrivateWebM::loadFinished):
(WebCore::mimeTypeCache):
(WebCore::MediaPlayerPrivateWebM::play):
(WebCore::MediaPlayerPrivateWebM::pause):
(WebCore::MediaPlayerPrivateWebM::currentMediaTime const):
(WebCore::MediaPlayerPrivateWebM::seek):
(WebCore::MediaPlayerPrivateWebM::seekable const):
(WebCore::MediaPlayerPrivateWebM::buffered const):
(WebCore::MediaPlayerPrivateWebM::setDuration):
(WebCore::MediaPlayerPrivateWebM::setRateDouble):
(WebCore::MediaPlayerPrivateWebM::effectiveRate const):
(WebCore::MediaPlayerPrivateWebM::setVolume):
(WebCore::MediaPlayerPrivateWebM::setMuted):
(WebCore::MediaPlayerPrivateWebM::createVideoFullscreenLayer):
(WebCore::MediaPlayerPrivateWebM::setVideoFullscreenLayer):
(WebCore::MediaPlayerPrivateWebM::setVideoFullscreenFrame):
(WebCore::MediaPlayerPrivateWebM::requiresTextTrackRepresentation const):
(WebCore::MediaPlayerPrivateWebM::syncTextTrackBounds):
(WebCore::MediaPlayerPrivateWebM::setTextTrackRepresentation):
(WebCore::MediaPlayerPrivateWebM::enqueueSamples):
(WebCore::MediaPlayerPrivateWebM::enqueueSamplesForTime):
(WebCore::MediaPlayerPrivateWebM::demuxWebMData):
(WebCore::MediaPlayerPrivateWebM::ensureLayer):
(WebCore::MediaPlayerPrivateWebM::ensureAudioRenderer):
(WebCore::MediaPlayerPrivateWebM::destroyLayer):
(WebCore::MediaPlayerPrivateWebM::destroyAudioRenderer):
(WebCore::MediaPlayerPrivateWebM::clearTracks):
(WebCore::MediaPlayerPrivateWebM::registerMediaEngine):
(WebCore::MediaPlayerPrivateWebM::isAvailable):
(WebCore::MediaPlayerPrivateWebM::getSupportedTypes):
(WebCore::MediaPlayerPrivateWebM::supportsType):
</pre>